### PR TITLE
feat(PRO-269): Wire up making broken link checker a default addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-	"name": "local-addon-broken-link-checker",
+	"name": "@getflywheel/local-addon-broken-link-checker",
 	"productName": "Broken Link Checker",
-	"version": "1.0.5",
+	"local": { "hidden": true },
+	"version": "1.0.7",
 	"author": "Coulter Peterson",
 	"keywords": [
 		"local-addon"


### PR DESCRIPTION
**Summary**

Wire up the ability to bring broken link checker into Local app via npm.