### PR TITLE
chore: Bump broken link checker version to 1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@getflywheel/local-addon-broken-link-checker",
 	"productName": "Broken Link Checker",
 	"local": { "hidden": true },
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"author": "Coulter Peterson",
 	"keywords": [
 		"local-addon"


### PR DESCRIPTION
Summary:

Bumping version to 1.0.9