### PR TITLE
Botz/chore/bump version to 1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@getflywheel/local-addon-broken-link-checker",
 	"productName": "Broken Link Checker",
 	"local": { "hidden": true },
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"author": "Coulter Peterson",
 	"keywords": [
 		"local-addon"

--- a/style.css
+++ b/style.css
@@ -10,7 +10,6 @@
 }
 
 .brokenLinkCheckWrap [class*=Banner] {
-	background: #fff !important;
 	padding-left: 10px !important;
 }
 
@@ -19,7 +18,7 @@
 }
 
 .brokenLinkCheckWrap .blcTooltipWrapper {
-	line-height: 1.3em; 
+	line-height: 1.3em;
 	white-space: normal;
 	overflow-wrap: break-word;
 }


### PR DESCRIPTION
Summary:

- Bump version to 1.0.11 and npm publish for Local app to consume
- Fixed visual bug within the Linker Checker's banner, see images of before/after

![Screen Shot 2020-08-14 at 1 35 34 PM](https://user-images.githubusercontent.com/62450648/90286678-f569a680-de3b-11ea-9947-be6e275d3248.png)

![Screen Shot 2020-08-14 at 2 29 53 PM](https://user-images.githubusercontent.com/62450648/90286690-fc90b480-de3b-11ea-8b98-8b3b56fdd7cf.png)

![Screen Shot 2020-08-14 at 2 30 15 PM](https://user-images.githubusercontent.com/62450648/90286700-031f2c00-de3c-11ea-8288-a06100badb72.png)

