### PR TITLE
chore(LOC-2540): Bump version and publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@getflywheel/local-addon-broken-link-checker",
 	"productName": "Broken Link Checker",
 	"local": { "hidden": true },
-	"version": "1.0.14",
+	"version": "1.0.15",
 	"author": "Coulter Peterson",
 	"keywords": [
 		"local-addon"
@@ -60,6 +60,6 @@
 		"prop-types"
 	],
 	"engines": {
-		"local-by-flywheel": "^5.0.0"
+		"local-by-flywheel": "^5.9.9"
 	}
 }


### PR DESCRIPTION
**Summary:**

Bump version of Link Checker and publish to git.

Added the following:
- Test site .zip file to test the integrity of Link Checker's expected errors
- Allow router mode of Local Host to work with Link Checker